### PR TITLE
Don't convert type to a string if it isn't required

### DIFF
--- a/mongoengine/base/datastructures.py
+++ b/mongoengine/base/datastructures.py
@@ -214,8 +214,13 @@ class EmbeddedDocumentList(BaseList):
         """
         for key, expected_value in kwargs.items():
             doc_val = getattr(embedded_doc, key)
-            if doc_val != expected_value and six.text_type(doc_val) != expected_value:
-                return False
+            if isinstance(expected_value, six.text_type):
+                if doc_val != expected_value and six.text_type(doc_val) != expected_value:
+                    return False
+            else:
+                if doc_val != expected_value:
+                    return False
+
         return True
 
     @classmethod

--- a/mongoengine/base/datastructures.py
+++ b/mongoengine/base/datastructures.py
@@ -215,7 +215,10 @@ class EmbeddedDocumentList(BaseList):
         for key, expected_value in kwargs.items():
             doc_val = getattr(embedded_doc, key)
             if isinstance(expected_value, six.text_type):
-                if doc_val != expected_value and six.text_type(doc_val) != expected_value:
+                # If the expected value is not a string then converting the
+                # doc_val to a string just wastes a lot of time
+                if doc_val != expected_value and \
+                six.text_type(doc_val) != expected_value:
                     return False
             else:
                 if doc_val != expected_value:


### PR DESCRIPTION
Just wasn't sure if I should merge this straight away. It should have the same behaviour, and all the mongoengine tests still pass, and all our tests still pass, but not sure if this will break anything.

Basically one of the slower parts in this is that it converts the value to a string every time it does a comparison, even if the expected value is something like an integer or float (which won't compare as True to a string). This doesn't do the conversion if the expected value isn't a string type.

Maybe it should be changed so it has
```python
if isinstance(expected_value, (int, float):
    if doc_val != expected_value:
        return False
else:
   ...
```
instead?